### PR TITLE
Fix timeouts in requesting pixabay footage

### DIFF
--- a/pipe/stocks.ts
+++ b/pipe/stocks.ts
@@ -119,7 +119,7 @@ const pixabayStock = async (
 	const videoUrl = video.videos['medium'].url;
 
 	return {
-		url: videoUrl,
+		url: videoUrl + '&download=1',
 		duration: video.duration,
 		id: video.id,
 	};


### PR DESCRIPTION
Viemo stream urls require adding download=1 query parameter to be downloaded

Fixes #4 